### PR TITLE
Use last git 1.8 branch

### DIFF
--- a/org.freedesktop.Platform.VAAPI.Intel.json
+++ b/org.freedesktop.Platform.VAAPI.Intel.json
@@ -14,9 +14,9 @@
             "config-opts": [ "--disable-static", "LIBVA_DRIVERS_PATH=/usr/lib/dri/intel-vaapi-driver" ],
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://www.freedesktop.org/software/vaapi/releases/libva-intel-driver/intel-vaapi-driver-1.8.2.tar.bz2",
-                    "sha256": "866cdf9974911e58b0d3a2cade29dbe7b5b68836e142cf092b99db68e366b702"
+                    "type": "git",
+                    "url": "https://github.com/intel/intel-vaapi-driver.git",
+                    "branch": "fcf9041b29cee938a228dc7950955ccebb43c6bf"
                 }
             ]
         },
@@ -36,3 +36,4 @@
         }
     ]
 }
+


### PR DESCRIPTION
It contains bugfixes, mainly for VP9 decoding.
cf https://github.com/intel/intel-vaapi-driver/issues/262